### PR TITLE
Changed header image to use post-thumbnail instead of full

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -62,6 +62,7 @@ function bulan_theme_setup() {
 
 	// Enable support for Post Thumbnails.
 	add_theme_support( 'post-thumbnails' );
+	set_post_thumbnail_size( 2000, 480, array( 'center', 'center') );
 
 	// Register custom navigation menu.
 	register_nav_menus(

--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -71,7 +71,7 @@ function bulan_custom_header() {
 	$header = get_header_image();
 
 	// Get the featured image
-	$featured = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'full' );
+	$featured = wp_get_attachment_image_src( get_post_thumbnail_id( get_the_ID() ), 'post-thumbnail' );
 
 	// Set up empty variable
 	$image = '';


### PR DESCRIPTION
Using the full image was causing stupid load times for the full 6mb images my client was uploading to Wordpress.
This should fix it to use a resized and cropped version of the image instead of loading the whole image and then hiding some of it with CSS.
I've used it locally and it seems to work fine.
