### PR TITLE
Remove unneeded "role" tags

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,7 +1,7 @@
 <?php get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 
 			<section class="error-404 not-found">
 

--- a/archive.php
+++ b/archive.php
@@ -1,7 +1,7 @@
 <?php get_header(); ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main" role="main" <?php hybrid_attr( 'content' ); ?>>
+		<main id="main" class="site-main" <?php hybrid_attr( 'content' ); ?>>
 
 			<?php if ( have_posts() ) : ?>
 

--- a/author.php
+++ b/author.php
@@ -1,7 +1,7 @@
 <?php get_header(); ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main" role="main" <?php hybrid_attr( 'content' ); ?>>
+		<main id="main" class="site-main" <?php hybrid_attr( 'content' ); ?>>
 
 			<?php if ( have_posts() ) : ?>
 

--- a/footer.php
+++ b/footer.php
@@ -3,7 +3,7 @@
 
 	<?php get_sidebar( 'footer' ); // Loads the sidebar-footer.php template.  ?>
 
-	<footer id="colophon" class="site-footer" role="contentinfo" <?php hybrid_attr( 'footer' ); ?>>
+	<footer id="colophon" class="site-footer" <?php hybrid_attr( 'footer' ); ?>>
 		<div class="wide-container">
 
 			<div class="site-info">

--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@
 
 	<?php get_template_part( 'menu', 'primary' ); // Loads the menu-primary.php template. ?>
 
-	<header id="masthead" class="site-header" role="banner" <?php hybrid_attr( 'header' ); ?>>
+	<header id="masthead" class="site-header" <?php hybrid_attr( 'header' ); ?>>
 
 		<div class="site-branding">
 			<div class="wide-container">

--- a/image.php
+++ b/image.php
@@ -7,7 +7,7 @@
 	<?php endif; ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main" <?php hybrid_attr( 'content' ); ?>>
+		<main id="main" class="site-main" <?php hybrid_attr( 'content' ); ?>>
 
 			<?php while ( have_posts() ) : the_post(); ?>
 

--- a/menu-primary.php
+++ b/menu-primary.php
@@ -5,7 +5,7 @@ if ( ! has_nav_menu( 'primary' ) ) {
 }
 ?>
 
-<nav id="site-navigation" class="main-navigation" role="navigation" <?php hybrid_attr( 'menu' ); ?>>
+<nav id="site-navigation" class="main-navigation" <?php hybrid_attr( 'menu' ); ?>>
 
 	<div class="wide-container">
 

--- a/page-templates/home-grid.php
+++ b/page-templates/home-grid.php
@@ -5,7 +5,7 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main grid" role="main" <?php hybrid_attr( 'content' ); ?>>
+		<main id="main" class="site-main grid" <?php hybrid_attr( 'content' ); ?>>
 
 			<?php 
 			$paged = ( get_query_var( 'page' ) ) ? get_query_var( 'page' ) : 1;

--- a/page-templates/home-list.php
+++ b/page-templates/home-list.php
@@ -5,7 +5,7 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main list" role="main" <?php hybrid_attr( 'content' ); ?>>
+		<main id="main" class="site-main list" <?php hybrid_attr( 'content' ); ?>>
 
 			<?php 
 			$paged = ( get_query_var( 'page' ) ) ? get_query_var( 'page' ) : 1;

--- a/page.php
+++ b/page.php
@@ -1,7 +1,7 @@
 <?php get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main" <?php hybrid_attr( 'content' ); ?>>
+		<main id="main" class="site-main" <?php hybrid_attr( 'content' ); ?>>
 
 			<?php while ( have_posts() ) : the_post(); ?>
 

--- a/search.php
+++ b/search.php
@@ -1,7 +1,7 @@
 <?php get_header(); ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main" role="main" <?php hybrid_attr( 'content' ); ?>>
+		<main id="main" class="site-main" <?php hybrid_attr( 'content' ); ?>>
 
 			<?php if ( have_posts() ) : ?>
 

--- a/single.php
+++ b/single.php
@@ -1,7 +1,7 @@
 <?php get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main" <?php hybrid_attr( 'content' ); ?>>
+		<main id="main" class="site-main" <?php hybrid_attr( 'content' ); ?>>
 
 			<?php while ( have_posts() ) : the_post(); ?>
 


### PR DESCRIPTION
According to the W3's HTML validator the "role" tags in tags like `<main>`, `<nav>`, `<footer>`, etc are unneeded. Check the validator for my site, which is running the Bulan theme:

https://validator.w3.org/nu/?doc=https%3A%2F%2Falaninkenya.org

Not sure whether you want this pull request against `dev` or `master`.
